### PR TITLE
Ensure keys are symbols so we dont duplicate string/symbols.

### DIFF
--- a/lib/shape/base.rb
+++ b/lib/shape/base.rb
@@ -72,7 +72,7 @@ module Shape
       #   property :practices, with: PracticeDecorator, context: {view: :summary}
       #
       def property(property_name, options={}, &block)
-        properties[property_name] = Shape::PropertyShaper.new(
+        properties[property_name.to_sym] = Shape::PropertyShaper.new(
           shaper_context, property_name, options, &block
         )
       end


### PR DESCRIPTION
Since this wasnt a hash with indifferent access, if a property was added as a string and then added again as a symbol, the property would be duplicated in the output which was undesirable. This ensures all keys are uniformly symbols.
