### PR TITLE
fix(PUI-21451): Handle delegation on ruby3

### DIFF
--- a/lib/shape/base.rb
+++ b/lib/shape/base.rb
@@ -100,9 +100,8 @@ module Shape
       #   to make `:_source` the default delegation target.
       #
       #   @return [void]
-      def delegate(*methods)
-        options = methods.extract_options!
-        super *methods, options.reverse_merge(to: :_source)
+      def delegate(*methods, to: :_source)
+        super(*methods, to: to)
       end
 
       def shape_collection(collection, sort_by: nil, **options)


### PR DESCRIPTION
This PR is a part of the ruby3 upgrade on platform-api. The pr explicitly adds the `to` keyword because, in ruby2, keyword and positional arguments could be automatically converted between each other. However, in Ruby 3, they are handled separately. See here for more info: [separation-of-positional-and-keyword-arguments-in-ruby-3-0](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).