### PR TITLE
feat(PDE-869): Fix Shape Gem Bug Around False Values

### DIFF
--- a/lib/shape/property_shaper.rb
+++ b/lib/shape/property_shaper.rb
@@ -38,7 +38,7 @@ module Shape
         delegate_property(from)
       end
     end
-    
+   
     def from(&block)
       if with = options[:with]
         define_from do
@@ -48,23 +48,23 @@ module Shape
         define_from(&block)
       end
     end
-    
+   
     def define_from(&block)
       unless shaper_context.method_defined?(name.to_sym)
         shaper_context.send(:define_method, name, &block)
       end
     end
-    
+   
     def with(&block)
       define_block(:with, &block)
     end
-    
+   
     def each_with(&block)
       define_block(:each_with, &block)
     end
-    
+   
     protected
-    
+   
     def define_block(type, &block)
       options[type] = Class.new do
         include Shape
@@ -72,7 +72,7 @@ module Shape
       end
       define_accessor(name, options[:from] || name)
     end
-    
+   
     def define_accessor(name, source_name)
       return if shaper_context.method_defined?(name.to_sym)
       options = self.options

--- a/lib/shape/property_shaper.rb
+++ b/lib/shape/property_shaper.rb
@@ -76,36 +76,42 @@ module Shape
     end
     
     def define_accessor(name, source_name)
-      if !shaper_context.method_defined?(name.to_sym)
-        _options = self.options
-        self.define_from do
-          return nil unless _source
-          result = begin
-                     _source_object = (name == source_name ? _source : self)
-                     if _source_object.respond_to?(source_name)
-                       _source_object.send(source_name)
-                     elsif _source.respond_to?(:[])
-                       if _source.respond_to?(:key?)
-                         if _source.key?(source_name.to_sym)
-                           _source[source_name.to_sym]
-                         elsif _source.key?(source_name.to_s)
-                           _source[source_name.to_s]
-                         end
-                       else
-                         _source[source_name.to_sym] || _source[source_name.to_s]
-                       end
-                     else
-                       nil
-                     end
-                   end
-          
-          if !result.nil? && with = _options[:with]
-            with.shape(result, parent: self)
-          elsif each_with = _options[:each_with]
-            each_with.shape_collection(result, parent: self, sort_by: _options[:sort_by])
-          else
-            result
+      return if shaper_context.method_defined?(name.to_sym)
+      
+      options = self.options
+      
+      define_from do
+        # Define helpers inside block for visibility
+        fetch_from_hash = ->(source, key) do
+          if source.respond_to?(:key?)
+            return source[key.to_sym] if source.key?(key.to_sym)
+            return source[key.to_s] if source.key?(key.to_s)
           end
+          source[key.to_sym] || source[key.to_s]
+        end
+        
+        fetch_value = ->(name_param, source_name_param, source) do
+          source_object = (name_param == source_name_param ? source : self)
+          
+          if source_object.respond_to?(source_name_param)
+            source_object.send(source_name_param)
+          elsif source.respond_to?(:[])
+            fetch_from_hash.call(source, source_name_param)
+          else
+            nil
+          end
+        end
+        
+        return nil unless _source
+        
+        result = fetch_value.call(name, source_name, _source)
+        
+        if !result.nil? && (with = options[:with])
+          with.shape(result, parent: self)
+        elsif (each_with = options[:each_with])
+          each_with.shape_collection(result, parent: self, sort_by: options[:sort_by])
+        else
+          result
         end
       end
     end

--- a/lib/shape/property_shaper.rb
+++ b/lib/shape/property_shaper.rb
@@ -74,29 +74,31 @@ module Shape
 
     def define_accessor(name, source_name)
       return if shaper_context.method_defined?(name.to_sym)
-      
+
       options = self.options
-      define_from do
-        # Define helpers inside block for visibility
-        fetch_from_hash = ->(source, key) do
-          if source.respond_to?(:key?)
-            source.key?(key.to_sym) ? source[key.to_sym] : (source.key?(key.to_s) ? source[key.to_s] : nil)
-          end
+      fetch_from_hash = ->(source, key) do
+        if source.respond_to?(:key?)
+          source.key?(key.to_sym) ? source[key.to_sym] : (source.key?(key.to_s) ? source[key.to_s] : nil)
+        else
           source[key.to_sym] || source[key.to_s]
         end
-        fetch_value = ->(name_param, source_name_param, source) do
-          source_object = (name_param == source_name_param ? source : self)
-          if source_object.respond_to?(source_name_param)
-            source_object.send(source_name_param)
-          elsif source.respond_to?(:[])
-            fetch_from_hash.call(source, source_name_param)
-          else
-            nil
-          end
+      end
+
+      fetch_value = ->(self_context, source_context) do
+        source_object = (name == source_name ? source_context : self_context)
+        if source_object.respond_to?(source_name)
+          source_object.send(source_name)
+        elsif source_context.respond_to?(:[])
+          fetch_from_hash.call(source_context, source_name)
+        else
+          nil
         end
+      end
+
+      define_from do
         return nil unless _source
-        
-        result = fetch_value.call(name, source_name, _source)
+
+        result = fetch_value.call(self, _source)
         if !result.nil? && (with = options[:with])
           with.shape(result, parent: self)
         elsif (each_with = options[:each_with])

--- a/lib/shape/property_shaper.rb
+++ b/lib/shape/property_shaper.rb
@@ -32,7 +32,8 @@ module Shape
       self.options = options
       if block
         instance_eval(&block)
-      else from = options[:from] || name
+      else
+        from = options[:from] || name
         define_accessor(name, from)
         delegate_property(from)
       end
@@ -43,7 +44,8 @@ module Shape
         define_from do
           with.shape(instance_eval(&block))
         end
-      else define_from(&block)
+      else
+        define_from(&block)
       end
     end
 
@@ -72,6 +74,7 @@ module Shape
 
     def define_accessor(name, source_name)
       return if shaper_context.method_defined?(name.to_sym)
+      
       options = self.options
       define_from do
         # Define helpers inside block for visibility
@@ -87,16 +90,19 @@ module Shape
             source_object.send(source_name_param)
           elsif source.respond_to?(:[])
             fetch_from_hash.call(source, source_name_param)
-          else nil
+          else
+            nil
           end
         end
         return nil unless _source
+        
         result = fetch_value.call(name, source_name, _source)
         if !result.nil? && (with = options[:with])
           with.shape(result, parent: self)
         elsif (each_with = options[:each_with])
           each_with.shape_collection(result, parent: self, sort_by: options[:sort_by])
-        else result
+        else
+          result
         end
       end
     end

--- a/lib/shape/property_shaper.rb
+++ b/lib/shape/property_shaper.rb
@@ -22,16 +22,16 @@ module Shape
   #   end
   class PropertyShaper
     include Shape::Base::ClassMethods
-
+    
     attr_accessor :name
     attr_accessor :shaper_context
     attr_accessor :options
-
+    
     def initialize(shaper_context, name, options={}, &block)
       self.shaper_context = shaper_context
       self.name = name
       self.options = options
-
+      
       if block
         instance_eval(&block)
       else
@@ -40,7 +40,7 @@ module Shape
         delegate_property(from)
       end
     end
-
+    
     def from(&block)
       if with = options[:with]
         define_from do
@@ -50,23 +50,23 @@ module Shape
         define_from(&block)
       end
     end
-
+    
     def define_from(&block)
       unless shaper_context.method_defined?(name.to_sym)
         shaper_context.send(:define_method, name, &block)
       end
     end
-
+    
     def with(&block)
       define_block(:with, &block)
     end
-
+    
     def each_with(&block)
       define_block(:each_with, &block)
     end
-
+    
     protected
-
+    
     def define_block(type, &block)
       options[type] = Class.new do
         include Shape
@@ -74,22 +74,31 @@ module Shape
       end
       define_accessor(name, options[:from] || name)
     end
-
+    
     def define_accessor(name, source_name)
       if !shaper_context.method_defined?(name.to_sym)
         _options = self.options
         self.define_from do
           return nil unless _source
           result = begin
-            _source_object = (name == source_name ? _source : self)
-
-            if _source_object.respond_to?(source_name)
-              _source_object.send(source_name)
-            elsif _source.respond_to?(:[])
-              _source.send(:[], source_name.to_sym) || _source.send(:[], source_name.to_s)
-            end
-
-          end
+                     _source_object = (name == source_name ? _source : self)
+                     if _source_object.respond_to?(source_name)
+                       _source_object.send(source_name)
+                     elsif _source.respond_to?(:[])
+                       if _source.respond_to?(:key?)
+                         if _source.key?(source_name.to_sym)
+                           _source[source_name.to_sym]
+                         elsif _source.key?(source_name.to_s)
+                           _source[source_name.to_s]
+                         end
+                       else
+                         _source[source_name.to_sym] || _source[source_name.to_s]
+                       end
+                     else
+                       nil
+                     end
+                   end
+          
           if !result.nil? && with = _options[:with]
             with.shape(result, parent: self)
           elsif each_with = _options[:each_with]
@@ -100,6 +109,5 @@ module Shape
         end
       end
     end
-
   end
 end

--- a/lib/shape/property_shaper.rb
+++ b/lib/shape/property_shaper.rb
@@ -26,12 +26,10 @@ module Shape
     attr_accessor :name
     attr_accessor :shaper_context
     attr_accessor :options
-    
     def initialize(shaper_context, name, options={}, &block)
       self.shaper_context = shaper_context
       self.name = name
       self.options = options
-      
       if block
         instance_eval(&block)
       else
@@ -77,9 +75,7 @@ module Shape
     
     def define_accessor(name, source_name)
       return if shaper_context.method_defined?(name.to_sym)
-      
       options = self.options
-      
       define_from do
         # Define helpers inside block for visibility
         fetch_from_hash = ->(source, key) do
@@ -92,7 +88,6 @@ module Shape
         
         fetch_value = ->(name_param, source_name_param, source) do
           source_object = (name_param == source_name_param ? source : self)
-          
           if source_object.respond_to?(source_name_param)
             source_object.send(source_name_param)
           elsif source.respond_to?(:[])
@@ -101,11 +96,8 @@ module Shape
             nil
           end
         end
-        
         return nil unless _source
-        
         result = fetch_value.call(name, source_name, _source)
-        
         if !result.nil? && (with = options[:with])
           with.shape(result, parent: self)
         elsif (each_with = options[:each_with])

--- a/lib/shape/property_shaper.rb
+++ b/lib/shape/property_shaper.rb
@@ -25,7 +25,7 @@ module Shape
     attr_accessor :name
     attr_accessor :shaper_context
     attr_accessor :options
-    
+
     def initialize(shaper_context, name, options = {}, &block)
       self.shaper_context = shaper_context
       self.name = name
@@ -37,7 +37,7 @@ module Shape
       delegate_property(from)
       end
     end
-    
+
     def from(&block)
       if with = options[:with]
         define_from do
@@ -46,21 +46,21 @@ module Shape
       else define_from(&block)
       end
     end
-    
+
     def define_from(&block)
       unless shaper_context.method_defined?(name.to_sym)
         shaper_context.send(:define_method, name, &block)
       end
     end
-    
+
     def with(&block)
       define_block(:with, &block)
     end
-    
+
     def each_with(&block)
       define_block(:each_with, &block)
     end
-    
+
     protected
     def define_block(type, &block)
       options[type] = Class.new do
@@ -69,7 +69,7 @@ module Shape
       end
       define_accessor(name, options[:from] || name)
     end
-    
+
     def define_accessor(name, source_name)
       return if shaper_context.method_defined?(name.to_sym)
       options = self.options

--- a/lib/shape/property_shaper.rb
+++ b/lib/shape/property_shaper.rb
@@ -22,7 +22,6 @@ module Shape
   #   end
   class PropertyShaper
     include Shape::Base::ClassMethods
-    
     attr_accessor :name
     attr_accessor :shaper_context
     attr_accessor :options
@@ -33,10 +32,9 @@ module Shape
       self.options = options
       if block
         instance_eval(&block)
-      else
-        from = options[:from] || name
-        define_accessor(name, from)
-        delegate_property(from)
+      else from = options[:from] || name
+      define_accessor(name, from)
+      delegate_property(from)
       end
     end
     
@@ -45,8 +43,7 @@ module Shape
         define_from do
           with.shape(instance_eval(&block))
         end
-      else
-        define_from(&block)
+      else define_from(&block)
       end
     end
     
@@ -65,7 +62,6 @@ module Shape
     end
     
     protected
-    
     def define_block(type, &block)
       options[type] = Class.new do
         include Shape
@@ -76,41 +72,31 @@ module Shape
     
     def define_accessor(name, source_name)
       return if shaper_context.method_defined?(name.to_sym)
-      
       options = self.options
-      
       define_from do
         # Define helpers inside block for visibility
-        
         fetch_from_hash = ->(source, key) do
           if source.respond_to?(:key?)
             source.key?(key.to_sym) ? source[key.to_sym] : (source.key?(key.to_s) ? source[key.to_s] : nil)
           end
           source[key.to_sym] || source[key.to_s]
         end
-        
         fetch_value = ->(name_param, source_name_param, source) do
           source_object = (name_param == source_name_param ? source : self)
-          
           if source_object.respond_to?(source_name_param)
             source_object.send(source_name_param)
           elsif source.respond_to?(:[])
             fetch_from_hash.call(source, source_name_param)
-          else
-            nil
+          else nil
           end
         end
-        
         return nil unless _source
-        
         result = fetch_value.call(name, source_name, _source)
-        
         if !result.nil? && (with = options[:with])
           with.shape(result, parent: self)
         elsif (each_with = options[:each_with])
           each_with.shape_collection(result, parent: self, sort_by: options[:sort_by])
-        else
-          result
+        else result
         end
       end
     end

--- a/lib/shape/property_shaper.rb
+++ b/lib/shape/property_shaper.rb
@@ -22,7 +22,7 @@ module Shape
   #   end
   class PropertyShaper
     include Shape::Base::ClassMethods
-    
+
     attr_accessor :name
     attr_accessor :shaper_context
     attr_accessor :options
@@ -38,7 +38,7 @@ module Shape
         delegate_property(from)
       end
     end
-   
+
     def from(&block)
       if with = options[:with]
         define_from do
@@ -48,23 +48,23 @@ module Shape
         define_from(&block)
       end
     end
-   
+
     def define_from(&block)
       unless shaper_context.method_defined?(name.to_sym)
         shaper_context.send(:define_method, name, &block)
       end
     end
-   
+
     def with(&block)
       define_block(:with, &block)
     end
-   
+
     def each_with(&block)
       define_block(:each_with, &block)
     end
-   
+
     protected
-   
+
     def define_block(type, &block)
       options[type] = Class.new do
         include Shape
@@ -72,7 +72,7 @@ module Shape
       end
       define_accessor(name, options[:from] || name)
     end
-   
+
     def define_accessor(name, source_name)
       return if shaper_context.method_defined?(name.to_sym)
       options = self.options
@@ -85,7 +85,7 @@ module Shape
           end
           source[key.to_sym] || source[key.to_s]
         end
-        
+
         fetch_value = ->(name_param, source_name_param, source) do
           source_object = (name_param == source_name_param ? source : self)
           if source_object.respond_to?(source_name_param)

--- a/lib/shape/property_shaper.rb
+++ b/lib/shape/property_shaper.rb
@@ -22,12 +22,12 @@ module Shape
   #   end
   class PropertyShaper
     include Shape::Base::ClassMethods
-
+    
     attr_accessor :name
     attr_accessor :shaper_context
     attr_accessor :options
-
-    def initialize(shaper_context, name, options={}, &block)
+    
+    def initialize(shaper_context, name, options = {}, &block)
       self.shaper_context = shaper_context
       self.name = name
       self.options = options
@@ -39,7 +39,7 @@ module Shape
         delegate_property(from)
       end
     end
-
+    
     def from(&block)
       if with = options[:with]
         define_from do
@@ -49,23 +49,23 @@ module Shape
         define_from(&block)
       end
     end
-
+    
     def define_from(&block)
       unless shaper_context.method_defined?(name.to_sym)
         shaper_context.send(:define_method, name, &block)
       end
     end
-
+    
     def with(&block)
       define_block(:with, &block)
     end
-
+    
     def each_with(&block)
       define_block(:each_with, &block)
     end
-
+    
     protected
-
+    
     def define_block(type, &block)
       options[type] = Class.new do
         include Shape
@@ -73,25 +73,25 @@ module Shape
       end
       define_accessor(name, options[:from] || name)
     end
-
+    
     def define_accessor(name, source_name)
       return if shaper_context.method_defined?(name.to_sym)
-
+      
       options = self.options
-
+      
       define_from do
         # Define helpers inside block for visibility
-
+        
         fetch_from_hash = ->(source, key) do
           if source.respond_to?(:key?)
             source.key?(key.to_sym) ? source[key.to_sym] : (source.key?(key.to_s) ? source[key.to_s] : nil)
           end
           source[key.to_sym] || source[key.to_s]
         end
-
+        
         fetch_value = ->(name_param, source_name_param, source) do
           source_object = (name_param == source_name_param ? source : self)
-
+          
           if source_object.respond_to?(source_name_param)
             source_object.send(source_name_param)
           elsif source.respond_to?(:[])
@@ -100,11 +100,11 @@ module Shape
             nil
           end
         end
-
+        
         return nil unless _source
-
+        
         result = fetch_value.call(name, source_name, _source)
-
+        
         if !result.nil? && (with = options[:with])
           with.shape(result, parent: self)
         elsif (each_with = options[:each_with])

--- a/lib/shape/property_shaper.rb
+++ b/lib/shape/property_shaper.rb
@@ -26,6 +26,7 @@ module Shape
     attr_accessor :name
     attr_accessor :shaper_context
     attr_accessor :options
+
     def initialize(shaper_context, name, options={}, &block)
       self.shaper_context = shaper_context
       self.name = name
@@ -75,19 +76,22 @@ module Shape
 
     def define_accessor(name, source_name)
       return if shaper_context.method_defined?(name.to_sym)
+
       options = self.options
+
       define_from do
         # Define helpers inside block for visibility
+
         fetch_from_hash = ->(source, key) do
           if source.respond_to?(:key?)
-            return source[key.to_sym] if source.key?(key.to_sym)
-            return source[key.to_s] if source.key?(key.to_s)
+            source.key?(key.to_sym) ? source[key.to_sym] : (source.key?(key.to_s) ? source[key.to_s] : nil)
           end
           source[key.to_sym] || source[key.to_s]
         end
 
         fetch_value = ->(name_param, source_name_param, source) do
           source_object = (name_param == source_name_param ? source : self)
+
           if source_object.respond_to?(source_name_param)
             source_object.send(source_name_param)
           elsif source.respond_to?(:[])
@@ -96,8 +100,11 @@ module Shape
             nil
           end
         end
+
         return nil unless _source
+
         result = fetch_value.call(name, source_name, _source)
+
         if !result.nil? && (with = options[:with])
           with.shape(result, parent: self)
         elsif (each_with = options[:each_with])

--- a/lib/shape/property_shaper.rb
+++ b/lib/shape/property_shaper.rb
@@ -33,8 +33,8 @@ module Shape
       if block
         instance_eval(&block)
       else from = options[:from] || name
-      define_accessor(name, from)
-      delegate_property(from)
+        define_accessor(name, from)
+        delegate_property(from)
       end
     end
 

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -1,40 +1,35 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe Shape::PropertyShaper do
-  let(:context_class) do
+  let(:context_class) {
     Class.new do
       include Shape::Base
       attr_accessor :_source
     end
-  end
+  }
 
-  let(:source) do
+  let(:source) {
     Struct.new(:name, :age).new('Alice', 42)
-  end
+  }
 
-  let(:hash_source) do
+  let(:hash_source) {
     {
       'name' => 'Bob',
       :age => 30
     }
-  end
+  }
 
   context 'Given an object with method attributes' do
-
     let(:source) {
-      OpenStruct.new.tap do | person |
-        person.name = 'John Smith'
-        person.age = 34
-        person.ssn = 123456789
-        person.children = [
-          OpenStruct.new.tap do | child |
-            child.name = 'Jimmy Smith'
-          end,
-          OpenStruct.new.tap do | child |
-            child.name = 'Jane Smith'
-          end,
+      OpenStruct.new(
+        name: 'John Smith',
+        age: 34,
+        ssn: 123_456_789,
+        children: [
+          OpenStruct.new(name: 'Jimmy Smith'),
+          OpenStruct.new(name: 'Jane Smith')
         ]
-      end
+      )
     }
 
     context 'and a Shape decorator' do
@@ -71,7 +66,7 @@ describe Shape::PropertyShaper do
 
   context 'Given a hash with attributes' do
 
-    let(:source) do
+    let(:source) {
       {
         name: 'John Smith',
         age: 34,
@@ -88,7 +83,7 @@ describe Shape::PropertyShaper do
           name: 'Sally Smith'
         }
       }
-    end
+    }
 
     context 'and a Shape decorator' do
 
@@ -232,12 +227,8 @@ describe Shape::PropertyShaper do
 
           def all_children
             [
-              OpenStruct.new.tap do | child |
-                child.name = 'Joseph Smith'
-              end,
-              OpenStruct.new.tap do | child |
-                child.name = 'Janet Smith'
-              end
+              OpenStruct.new(name: 'Joseph Smith'),
+              OpenStruct.new(name: 'Janet Smith')
             ]
           end
         end)
@@ -393,7 +384,7 @@ describe Shape::PropertyShaper do
 
   context 'Given a hash with string attributes' do
 
-    let(:source) do
+    let(:source) {
       {
         'name' => 'John Smith',
         'age' => 34,
@@ -410,7 +401,7 @@ describe Shape::PropertyShaper do
           'name' => 'Sally Smith'
         }
       }
-    end
+    }
 
     context 'and a Shape decorator' do
 
@@ -478,13 +469,13 @@ describe Shape::PropertyShaper do
   end
 
   context 'value resolution' do
-    let(:source) do
+    let(:source) {
       OpenStruct.new(name: 'Alice', age: 42)
-    end
+    }
 
-    let(:hash_source) do
+    let(:hash_source) {
       { name: 'Bob', age: 30 }
-    end
+    }
 
     let(:instance) { context_class.new }
 
@@ -586,4 +577,3 @@ describe Shape::PropertyShaper do
     end
   end
 end
-

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -136,7 +136,7 @@ describe Shape::PropertyShaper do
         }
 
         it 'exposes and shapes each child element of the property with the provided decorator' do
-          expect(subject.children.map(&:name)).to eq([ 'Jimmy Smith', 'Jane Smith' ])
+          expect(subject.children.map(&:name)).to eq(['Jimmy Smith', 'Jane Smith'])
         end
       end
 
@@ -156,7 +156,7 @@ describe Shape::PropertyShaper do
           }
 
           it 'sorts, exposes, and shapes each child element of the property with the provided decorator' do
-            expect(subject.children.map(&:name)).to eq([ 'Jane Smith', 'Jimmy Smith' ])
+            expect(subject.children.map(&:name)).to eq(['Jane Smith', 'Jimmy Smith'])
           end
         end
       end

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -545,7 +545,6 @@ describe Shape::PropertyShaper do
     let(:children) { [{ name: 'Zoe' }, { name: 'Adam' }] }
     let(:unsorted) { [{ name: 'Zoe' }, { name: 'Adam' }] } # reverse to test sort, if needed
     let(:source) { { child: { name: 'Charlie' } } }
-
     let(:instance_one) { ParentDecorator.new(source) }
     let(:instance_two) { ParentDecorator.new(children: children) }
     let(:instance_three) { ParentDecorator.new(children: unsorted) }

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -1,4 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require 'ostruct'
 
 describe Shape::PropertyShaper do
 
@@ -461,8 +462,6 @@ describe Shape::PropertyShaper do
   end
 end
 
-require 'ostruct'
-
 RSpec.describe Shape::PropertyShaper do
   let(:context_class) do
     Class.new do
@@ -484,7 +483,6 @@ RSpec.describe Shape::PropertyShaper do
 
   describe 'value resolution' do
     it 'resolves value from object method' do
-
       context_class.class_eval do
         property :name
       end
@@ -495,7 +493,6 @@ RSpec.describe Shape::PropertyShaper do
     end
 
     it 'resolves value from hash using symbol key' do
-
       context_class.class_eval do
         property :age
       end
@@ -506,7 +503,6 @@ RSpec.describe Shape::PropertyShaper do
     end
 
     it 'resolves value from hash using string key fallback' do
-
       context_class.class_eval do
         property :name
       end
@@ -517,7 +513,6 @@ RSpec.describe Shape::PropertyShaper do
     end
 
     it 'returns nil when key is not found' do
-
       context_class.class_eval do
         property :missing
       end
@@ -528,7 +523,6 @@ RSpec.describe Shape::PropertyShaper do
     end
 
     it 'resolves using custom from alias' do
-
       context_class.class_eval do
         property :nickname, from: :name
       end
@@ -551,7 +545,6 @@ RSpec.describe Shape::PropertyShaper do
     end
 
     it 'shapes nested object with with: decorator' do
-
       ParentDecorator.class_eval do
         property :child, with: SimpleDecorator
       end
@@ -562,7 +555,6 @@ RSpec.describe Shape::PropertyShaper do
     end
 
     it 'shapes collection with each_with: decorator' do
-
       ParentDecorator.class_eval do
         property :children, each_with: SimpleDecorator
       end
@@ -576,7 +568,6 @@ RSpec.describe Shape::PropertyShaper do
     end
 
     it 'sorts shaped collection by provided attribute' do
-
       ParentDecorator.class_eval do
         property :children, each_with: SimpleDecorator, sort_by: :name
       end

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -1,5 +1,4 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
-require 'ostruct'
 
 describe Shape::PropertyShaper do
   let(:context_class) do
@@ -10,7 +9,7 @@ describe Shape::PropertyShaper do
   end
 
   let(:source) do
-    OpenStruct.new(name: 'Alice', age: 42)
+    Struct.new(:name, :age).new('Alice', 42)
   end
 
   let(:hash_source) do
@@ -531,6 +530,10 @@ describe Shape::PropertyShaper do
   end
 
   context 'with and each_with' do
+    let(:children) { [{ name: 'Zoe' }, { name: 'Adam' }] }
+    let(:unsorted) { [{ name: 'Zoe' }, { name: 'Adam' }] }
+    let(:source) { { child: { name: 'Charlie' } } }
+
     before do
       stub_const('SimpleDecorator', Class.new do
         include Shape::Base
@@ -546,7 +549,7 @@ describe Shape::PropertyShaper do
         property :child, with: SimpleDecorator
       end
 
-      instance = ParentDecorator.new({ child: { name: 'Charlie' } })
+      instance = ParentDecorator.new(source)
       expect(instance.child).to be_a(SimpleDecorator)
       expect(instance.child.name).to eq('Charlie')
     end
@@ -556,10 +559,6 @@ describe Shape::PropertyShaper do
         property :children, each_with: SimpleDecorator
       end
 
-      children = [
-        { name: 'Zoe' },
-        { name: 'Adam' }
-      ]
       instance = ParentDecorator.new({ children: children })
       expect(instance.children.map(&:name)).to contain_exactly('Zoe', 'Adam')
     end
@@ -569,10 +568,6 @@ describe Shape::PropertyShaper do
         property :children, each_with: SimpleDecorator, sort_by: :name
       end
 
-      unsorted = [
-        { name: 'Zoe' },
-        { name: 'Adam' }
-      ]
       instance = ParentDecorator.new({ children: unsorted })
       expect(instance.children.map(&:name)).to eq(['Adam', 'Zoe'])
     end

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -27,7 +27,7 @@ describe Shape::PropertyShaper do
         person.age = 34
         person.ssn = 123456789
         person.children = [
-            OpenStruct.new.tap do | child |
+          OpenStruct.new.tap do | child |
             child.name = 'Jimmy Smith'
           end,
           OpenStruct.new.tap do | child |

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -366,7 +366,7 @@ describe Shape::PropertyShaper do
         it 'exposes the nested properties' do
           expect(subject.to_hash[:dependents]).to eq({
             spouse: {
-               name: 'Sally Smith'
+              name: 'Sally Smith'
             },
             children: [
               {
@@ -374,7 +374,7 @@ describe Shape::PropertyShaper do
               },
               {
                 name: 'Jane Smith'
-               }
+              }
             ]
           })
         end

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -478,67 +478,84 @@ describe Shape::PropertyShaper do
   end
 
   context 'value resolution' do
-    it 'resolves value from object method' do
-      context_class.class_eval do
-        property :name
-      end
-
-      instance = context_class.new
-      instance._source = source
-      expect(instance.name).to eq('Alice')
+    let(:source) do
+      OpenStruct.new(name: 'Alice', age: 42)
     end
 
-    it 'resolves value from hash using symbol key' do
-      context_class.class_eval do
-        property :age
-      end
-
-      instance = context_class.new
-      instance._source = hash_source
-      expect(instance.age).to eq(30)
+    let(:hash_source) do
+      { name: 'Bob', age: 30 }
     end
 
-    it 'resolves value from hash using string key fallback' do
-      context_class.class_eval do
-        property :name
-      end
+    let(:instance) { context_class.new }
 
-      instance = context_class.new
-      instance._source = hash_source
-      expect(instance.name).to eq('Bob')
+    before do
+      instance._source = current_source
     end
 
-    it 'returns nil when key is not found' do
-      context_class.class_eval do
-        property :missing
+    context 'when resolving from object' do
+      let(:current_source) { source }
+
+      it 'resolves value from object method' do
+        context_class.class_eval do
+          property :name
+        end
+
+        expect(instance.name).to eq('Alice')
       end
 
-      instance = context_class.new
-      instance._source = hash_source
-      expect(instance.missing).to be_nil
+      it 'resolves using custom from alias' do
+        context_class.class_eval do
+          property :nickname, from: :name
+        end
+
+        expect(instance.nickname).to eq('Alice')
+      end
     end
 
-    it 'resolves using custom from alias' do
-      context_class.class_eval do
-        property :nickname, from: :name
+    context 'when resolving from hash' do
+      let(:current_source) { hash_source }
+
+      it 'resolves value using symbol key' do
+        context_class.class_eval do
+          property :age
+        end
+
+        expect(instance.age).to eq(30)
       end
 
-      instance = context_class.new
-      instance._source = source
-      expect(instance.nickname).to eq('Alice')
+      it 'resolves value using string key fallback' do
+        context_class.class_eval do
+          property :name
+        end
+
+        expect(instance.name).to eq('Bob')
+      end
+
+      it 'returns nil when key is not found' do
+        context_class.class_eval do
+          property :missing
+        end
+
+        expect(instance.missing).to be_nil
+      end
     end
   end
 
   context 'with and each_with' do
     let(:children) { [{ name: 'Zoe' }, { name: 'Adam' }] }
-    let(:unsorted) { [{ name: 'Zoe' }, { name: 'Adam' }] }
+    let(:unsorted) { [{ name: 'Zoe' }, { name: 'Adam' }] } # reverse to test sort, if needed
     let(:source) { { child: { name: 'Charlie' } } }
+
+    let(:instance_one) { ParentDecorator.new(source) }
+    let(:instance_two) { ParentDecorator.new(children: children) }
+    let(:instance_three) { ParentDecorator.new(children: unsorted) }
 
     before do
       stub_const('SimpleDecorator', Class.new do
         include Shape::Base
         property :name
       end)
+
       stub_const('ParentDecorator', Class.new do
         include Shape::Base
       end)
@@ -549,9 +566,8 @@ describe Shape::PropertyShaper do
         property :child, with: SimpleDecorator
       end
 
-      instance = ParentDecorator.new(source)
-      expect(instance.child).to be_a(SimpleDecorator)
-      expect(instance.child.name).to eq('Charlie')
+      expect(instance_one.child).to be_a(SimpleDecorator)
+      expect(instance_one.child.name).to eq('Charlie')
     end
 
     it 'shapes collection with each_with: decorator' do
@@ -559,8 +575,7 @@ describe Shape::PropertyShaper do
         property :children, each_with: SimpleDecorator
       end
 
-      instance = ParentDecorator.new({ children: children })
-      expect(instance.children.map(&:name)).to contain_exactly('Zoe', 'Adam')
+      expect(instance_two.children.map(&:name)).to contain_exactly('Zoe', 'Adam')
     end
 
     it 'sorts shaped collection by provided attribute' do
@@ -568,8 +583,7 @@ describe Shape::PropertyShaper do
         property :children, each_with: SimpleDecorator, sort_by: :name
       end
 
-      instance = ParentDecorator.new({ children: unsorted })
-      expect(instance.children.map(&:name)).to eq(['Adam', 'Zoe'])
+      expect(instance_three.children.map(&:name)).to eq(['Adam', 'Zoe'])
     end
   end
 end

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -251,7 +251,7 @@ describe Shape::PropertyShaper do
         }
 
         it 'exposes and shapes each child element of the property with the provided decorator' do
-          expect(subject.dependents.map(&:name)).to eq([ 'Joseph Smith', 'Janet Smith' ])
+          expect(subject.dependents.map(&:name)).to eq([ 'Joseph Smith', 'Janet Smith'])
         end
       end
     end
@@ -574,7 +574,7 @@ describe Shape::PropertyShaper do
         { name: 'Adam' }
       ]
       instance = ParentDecorator.new({ children: unsorted })
-      expect(instance.children.map(&:name)).to eq([ 'Adam', 'Zoe' ])
+      expect(instance.children.map(&:name)).to eq(['Adam', 'Zoe'])
     end
   end
 end

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -214,7 +214,7 @@ describe Shape::PropertyShaper do
         }
 
         it 'exposes and shapes each child element of the property with the provided decorator' do
-          expect(subject.dependents.map(&:name)).to eq([ 'Jimmy Smith', 'Jane Smith' ])
+          expect(subject.dependents.map(&:name)).to eq(['Jimmy Smith', 'Jane Smith'])
         end
       end
     end
@@ -251,7 +251,7 @@ describe Shape::PropertyShaper do
         }
 
         it 'exposes and shapes each child element of the property with the provided decorator' do
-          expect(subject.dependents.map(&:name)).to eq([ 'Joseph Smith', 'Janet Smith'])
+          expect(subject.dependents.map(&:name)).to eq(['Joseph Smith', 'Janet Smith'])
         end
       end
     end
@@ -326,7 +326,7 @@ describe Shape::PropertyShaper do
         }
 
         it 'exposes and shapes each child element of the property with the provided decorator' do
-          expect(subject.dependents.map(&:name)).to eq([ 'Jimmy Smith', 'Jane Smith' ])
+          expect(subject.dependents.map(&:name)).to eq(['Jimmy Smith', 'Jane Smith'])
         end
       end
     end

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -51,7 +51,6 @@ describe Shape::PropertyShaper do
         end
       end
     end
-
   end
 
   context 'Given a hash with attributes' do
@@ -83,7 +82,6 @@ describe Shape::PropertyShaper do
           property :name
           property :years_of_age, from: :age
         end)
-
       end
 
       context 'when shaped by the decorator' do
@@ -105,7 +103,6 @@ describe Shape::PropertyShaper do
           expect(subject).to_not respond_to(:age)
         end
       end
-
     end
 
     context 'and a Shape decorator property with each_with: option' do
@@ -115,12 +112,10 @@ describe Shape::PropertyShaper do
           include Shape::Base
           property :name
         end)
-
         stub_const('MockDecorator', Class.new do
           include Shape::Base
           property :children, each_with: ChildDecorator
         end)
-
       end
 
       context 'when shaped by the decorator' do
@@ -132,7 +127,6 @@ describe Shape::PropertyShaper do
         it 'exposes and shapes each child element of the property with the provided decorator' do
           expect(subject.children.map(&:name)).to eq(['Jimmy Smith', 'Jane Smith'])
         end
-
       end
 
       context 'and a sort_by: option' do
@@ -153,13 +147,9 @@ describe Shape::PropertyShaper do
           it 'sorts, exposes, and shapes each child element of the property with the provided decorator' do
             expect(subject.children.map(&:name)).to eq(['Jane Smith', 'Jimmy Smith'])
           end
-
         end
-
       end
-
     end
-
 
     context 'and a Shape decorator property with with: option' do
 
@@ -173,7 +163,6 @@ describe Shape::PropertyShaper do
           include Shape::Base
           property :spouse, with: SpouseDecorator
         end)
-
       end
 
       context 'when shaped by the decorator' do
@@ -185,9 +174,7 @@ describe Shape::PropertyShaper do
         it 'exposes and shapes child element of the property with the provided decorator' do
           expect(subject.spouse.name).to eq('Sally Smith')
         end
-
       end
-
     end
 
     context 'and a Shape decorator property with each_with: and from: options' do
@@ -197,7 +184,6 @@ describe Shape::PropertyShaper do
           include Shape::Base
           property :name
         end)
-
         stub_const('MockDecorator', Class.new do
           include Shape::Base
           property :dependents, from: :children, each_with: ChildDecorator
@@ -242,7 +228,6 @@ describe Shape::PropertyShaper do
             ]
           end
         end)
-
       end
 
       context 'when shaped by the decorator' do
@@ -254,9 +239,7 @@ describe Shape::PropertyShaper do
         it 'exposes and shapes each child element of the property with the provided decorator' do
           expect(subject.dependents.map(&:name)).to eq(['Joseph Smith', 'Janet Smith'])
         end
-
       end
-
     end
 
     context 'and a Shape decorator property using a each_with block' do
@@ -270,11 +253,10 @@ describe Shape::PropertyShaper do
             end
           end
         end)
-
       end
 
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
@@ -282,13 +264,11 @@ describe Shape::PropertyShaper do
         it 'exposes and shapes each child element of the property with the provided decorator' do
           expect(subject.children.map(&:name)).to eq(['Jimmy Smith', 'Jane Smith'])
         end
-
       end
-
     end
 
     context 'and a Shape decorator property using a with block' do
-
+      
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -298,11 +278,10 @@ describe Shape::PropertyShaper do
             end
           end
         end)
-
       end
 
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
@@ -310,14 +289,11 @@ describe Shape::PropertyShaper do
         it 'exposes and shapes the child element of the property with the provided decorator' do
           expect(subject.spouse.name).to eq('Sally Smith')
         end
-
       end
-
     end
 
-
     context 'and a Shape decorator property using from: option and a each_with block' do
-
+      
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -327,11 +303,10 @@ describe Shape::PropertyShaper do
             end
           end
         end)
-
       end
 
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
@@ -339,13 +314,11 @@ describe Shape::PropertyShaper do
         it 'exposes and shapes each child element of the property with the provided decorator' do
           expect(subject.dependents.map(&:name)).to eq(['Jimmy Smith', 'Jane Smith'])
         end
-
       end
-
     end
 
     context 'and a Shape decorator property using from: option and a with block' do
-
+      
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -355,21 +328,17 @@ describe Shape::PropertyShaper do
             end
           end
         end)
-
       end
 
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
-
         it 'exposes and shapes the child element of the property with the provided decorator' do
           expect(subject.wife.name).to eq('Sally Smith')
         end
-
       end
-
     end
 
 
@@ -406,11 +375,8 @@ describe Shape::PropertyShaper do
             ]
           })
         end
-
       end
-
     end
-
   end
 
   context 'Given a hash with string attributes' do
@@ -435,14 +401,13 @@ describe Shape::PropertyShaper do
     end
 
     context 'and a Shape decorator' do
-
+      
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
           property :name
           property :years_of_age, from: :age
         end)
-
       end
 
       context 'when shaped by the decorator' do
@@ -464,7 +429,6 @@ describe Shape::PropertyShaper do
           expect(subject).to_not respond_to(:age)
         end
       end
-
     end
 
     context 'and a Shape decorator property with with: option and a from block' do
@@ -474,7 +438,6 @@ describe Shape::PropertyShaper do
           include Shape
           property :fullname, from: :name
         end)
-
         stub_const('MockDecorator', Class.new do
           include Shape
           property :first_child, with: ChildDecorator do
@@ -483,11 +446,10 @@ describe Shape::PropertyShaper do
             end
           end
         end)
-
       end
 
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
@@ -499,11 +461,8 @@ describe Shape::PropertyShaper do
         specify do
           expect(subject.to_hash).to eq({first_child: {fullname: 'Jimmy Smith'}})
         end
-
       end
-
     end
-
   end
 
 end
@@ -531,52 +490,58 @@ RSpec.describe Shape::PropertyShaper do
   
   describe 'value resolution' do
     it 'resolves value from object method' do
+      
       context_class.class_eval do
         property :name
       end
+      
       instance = context_class.new
       instance._source = source
-      
       expect(instance.name).to eq('Alice')
     end
     
     it 'resolves value from hash using symbol key' do
+      
       context_class.class_eval do
         property :age
       end
+      
       instance = context_class.new
       instance._source = hash_source
-      
       expect(instance.age).to eq(30)
     end
     
     it 'resolves value from hash using string key fallback' do
+      
       context_class.class_eval do
         property :name
       end
+      
       instance = context_class.new
       instance._source = hash_source
-      
       expect(instance.name).to eq('Bob')
     end
     
     it 'returns nil when key is not found' do
+      
       context_class.class_eval do
         property :missing
       end
+      
       instance = context_class.new
       instance._source = hash_source
-      
       expect(instance.missing).to be_nil
     end
     
     it 'resolves using custom from alias' do
+      
       context_class.class_eval do
         property :nickname, from: :name
       end
+      
+      
       instance = context_class.new
       instance._source = source
-      
       expect(instance.nickname).to eq('Alice')
     end
   end
@@ -587,24 +552,24 @@ RSpec.describe Shape::PropertyShaper do
         include Shape::Base
         property :name
       end)
-      
       stub_const('ParentDecorator', Class.new do
         include Shape::Base
       end)
     end
     
     it 'shapes nested object with with: decorator' do
+      
       ParentDecorator.class_eval do
         property :child, with: SimpleDecorator
       end
       
       instance = ParentDecorator.new({ child: { name: 'Charlie' } })
-      
       expect(instance.child).to be_a(SimpleDecorator)
       expect(instance.child.name).to eq('Charlie')
     end
     
     it 'shapes collection with each_with: decorator' do
+      
       ParentDecorator.class_eval do
         property :children, each_with: SimpleDecorator
       end
@@ -613,13 +578,12 @@ RSpec.describe Shape::PropertyShaper do
         { name: 'Zoe' },
         { name: 'Adam' }
       ]
-      
       instance = ParentDecorator.new({ children: children })
-      
       expect(instance.children.map(&:name)).to contain_exactly('Zoe', 'Adam')
     end
     
     it 'sorts shaped collection by provided attribute' do
+      
       ParentDecorator.class_eval do
         property :children, each_with: SimpleDecorator, sort_by: :name
       end
@@ -628,9 +592,7 @@ RSpec.describe Shape::PropertyShaper do
         { name: 'Zoe' },
         { name: 'Adam' }
       ]
-      
       instance = ParentDecorator.new({ children: unsorted })
-      
       expect(instance.children.map(&:name)).to eq(['Adam', 'Zoe'])
     end
   end

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -8,27 +8,27 @@ describe Shape::PropertyShaper do
       attr_accessor :_source
     end
   end
-  
+
   let(:source) do
     OpenStruct.new(name: 'Alice', age: 42)
   end
-  
+
   let(:hash_source) do
     {
       'name' => 'Bob',
       :age => 30
     }
   end
-  
+
   context 'Given an object with method attributes' do
-    
+
     let(:source) {
       OpenStruct.new.tap do | person |
         person.name = 'John Smith'
         person.age = 34
         person.ssn = 123456789
         person.children = [
-          OpenStruct.new.tap do | child |
+            OpenStruct.new.tap do | child |
             child.name = 'Jimmy Smith'
           end,
           OpenStruct.new.tap do | child |
@@ -37,9 +37,9 @@ describe Shape::PropertyShaper do
         ]
       end
     }
-    
+
     context 'and a Shape decorator' do
-      
+
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -47,21 +47,21 @@ describe Shape::PropertyShaper do
           property :years_of_age, from: :age
         end)
       end
-      
+
       context 'when shaped by the decorator' do
-        
+
         subject {
           MockDecorator.new(source)
         }
-        
+
         it 'exposes defined properties from source' do
           expect(subject.name).to eq('John Smith')
         end
-        
+
         it 'exposes defined properties renamed from source' do
           expect(subject.years_of_age).to eq(34)
         end
-        
+
         it 'does not expose unspecified attributes' do
           expect(subject).to_not respond_to(:ssn)
           expect(subject).to_not respond_to(:age)
@@ -69,9 +69,9 @@ describe Shape::PropertyShaper do
       end
     end
   end
-  
+
   context 'Given a hash with attributes' do
-    
+
     let(:source) do
       {
         name: 'John Smith',
@@ -90,9 +90,9 @@ describe Shape::PropertyShaper do
         }
       }
     end
-    
+
     context 'and a Shape decorator' do
-      
+
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -100,30 +100,30 @@ describe Shape::PropertyShaper do
           property :years_of_age, from: :age
         end)
       end
-      
+
       context 'when shaped by the decorator' do
-        
+
         subject {
           MockDecorator.new(source)
         }
-        
+
         it 'exposes defined properties from source' do
           expect(subject.name).to eq('John Smith')
         end
-        
+
         it 'exposes defined properties renamed from source' do
           expect(subject.years_of_age).to eq(34)
         end
-        
+
         it 'does not expose unspecified attributes' do
           expect(subject).to_not respond_to(:ssn)
           expect(subject).to_not respond_to(:age)
         end
       end
     end
-    
+
     context 'and a Shape decorator property with each_with: option' do
-      
+
       before do
         stub_const('ChildDecorator', Class.new do
           include Shape::Base
@@ -134,68 +134,68 @@ describe Shape::PropertyShaper do
           property :children, each_with: ChildDecorator
         end)
       end
-      
+
       context 'when shaped by the decorator' do
-        
+
         subject {
           MockDecorator.new(source)
         }
-        
+
         it 'exposes and shapes each child element of the property with the provided decorator' do
           expect(subject.children.map(&:name)).to eq([ 'Jimmy Smith', 'Jane Smith' ])
         end
       end
-      
+
       context 'and a sort_by: option' do
-        
+
         before do
           stub_const('MockDecorator', Class.new do
             include Shape::Base
             property :children, each_with: ChildDecorator, sort_by: :name
           end)
         end
-        
+
         context 'when shaped by the decorator' do
-          
+
           subject {
             MockDecorator.new(source)
           }
-          
+
           it 'sorts, exposes, and shapes each child element of the property with the provided decorator' do
             expect(subject.children.map(&:name)).to eq([ 'Jane Smith', 'Jimmy Smith' ])
           end
         end
       end
     end
-    
+
     context 'and a Shape decorator property with with: option' do
-      
+
       before do
         stub_const('SpouseDecorator', Class.new do
           include Shape::Base
           property :name
         end)
-        
+
         stub_const('MockDecorator', Class.new do
           include Shape::Base
           property :spouse, with: SpouseDecorator
         end)
       end
-      
+
       context 'when shaped by the decorator' do
-        
+
         subject {
           MockDecorator.new(source)
         }
-        
+
         it 'exposes and shapes child element of the property with the provided decorator' do
           expect(subject.spouse.name).to eq('Sally Smith')
         end
       end
     end
-    
+
     context 'and a Shape decorator property with each_with: and from: options' do
-      
+
       before do
         stub_const('ChildDecorator', Class.new do
           include Shape::Base
@@ -206,31 +206,31 @@ describe Shape::PropertyShaper do
           property :dependents, from: :children, each_with: ChildDecorator
         end)
       end
-      
+
       context 'when shaped by the decorator' do
-        
+
         subject {
           MockDecorator.new(source)
         }
-        
+
         it 'exposes and shapes each child element of the property with the provided decorator' do
           expect(subject.dependents.map(&:name)).to eq([ 'Jimmy Smith', 'Jane Smith' ])
         end
       end
     end
-    
+
     context 'and a Shape decorator property with each_with: and from: options and a decorator defined method' do
-      
+
       before do
         stub_const('ChildDecorator', Class.new do
           include Shape::Base
           property :name
         end)
-        
+
         stub_const('MockDecorator', Class.new do
           include Shape::Base
           property :dependents, from: :all_children, each_with: ChildDecorator
-          
+
           def all_children
             [
               OpenStruct.new.tap do | child |
@@ -243,21 +243,21 @@ describe Shape::PropertyShaper do
           end
         end)
       end
-      
+
       context 'when shaped by the decorator' do
-        
+
         subject {
           MockDecorator.new(source)
         }
-        
+
         it 'exposes and shapes each child element of the property with the provided decorator' do
           expect(subject.dependents.map(&:name)).to eq([ 'Joseph Smith', 'Janet Smith' ])
         end
       end
     end
-    
+
     context 'and a Shape decorator property using a each_with block' do
-      
+
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -268,21 +268,21 @@ describe Shape::PropertyShaper do
           end
         end)
       end
-      
+
       context 'when shaped by the decorator' do
-        
+
         subject {
           MockDecorator.new(source)
         }
-        
+
         it 'exposes and shapes each child element of the property with the provided decorator' do
           expect(subject.children.map(&:name)).to eq([ 'Jimmy Smith', 'Jane Smith' ])
         end
       end
     end
-    
+
     context 'and a Shape decorator property using a with block' do
-      
+
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -293,21 +293,21 @@ describe Shape::PropertyShaper do
           end
         end)
       end
-      
+
       context 'when shaped by the decorator' do
-        
+
         subject {
           MockDecorator.new(source)
         }
-        
+
         it 'exposes and shapes the child element of the property with the provided decorator' do
           expect(subject.spouse.name).to eq('Sally Smith')
         end
       end
     end
-    
+
     context 'and a Shape decorator property using from: option and a each_with block' do
-      
+
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -318,21 +318,21 @@ describe Shape::PropertyShaper do
           end
         end)
       end
-      
+
       context 'when shaped by the decorator' do
-        
+
         subject {
           MockDecorator.new(source)
         }
-        
+
         it 'exposes and shapes each child element of the property with the provided decorator' do
           expect(subject.dependents.map(&:name)).to eq([ 'Jimmy Smith', 'Jane Smith' ])
         end
       end
     end
-    
+
     context 'and a Shape decorator property using from: option and a with block' do
-      
+
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -343,9 +343,9 @@ describe Shape::PropertyShaper do
           end
         end)
       end
-      
+
       context 'when shaped by the decorator' do
-        
+
         subject {
           MockDecorator.new(source)
         }
@@ -354,9 +354,9 @@ describe Shape::PropertyShaper do
         end
       end
     end
-    
+
     context 'given nested decorated properties' do
-      
+
       before do
         stub_const('MockDecorator', Class.new do
           include Shape
@@ -366,13 +366,13 @@ describe Shape::PropertyShaper do
           end
         end)
       end
-      
+
       context 'when shaped by the decorator' do
-        
+
         subject {
           MockDecorator.new(source)
         }
-        
+
         it 'exposes the nested properties' do
           expect(subject.to_hash[:dependents]).to eq({
                                                        spouse: {
@@ -391,9 +391,9 @@ describe Shape::PropertyShaper do
       end
     end
   end
-  
+
   context 'Given a hash with string attributes' do
-    
+
     let(:source) do
       {
         'name' => 'John Smith',
@@ -412,9 +412,9 @@ describe Shape::PropertyShaper do
         }
       }
     end
-    
+
     context 'and a Shape decorator' do
-      
+
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -422,30 +422,30 @@ describe Shape::PropertyShaper do
           property :years_of_age, from: :age
         end)
       end
-      
+
       context 'when shaped by the decorator' do
-        
+
         subject {
           MockDecorator.new(source)
         }
-        
+
         it 'exposes defined properties from source' do
           expect(subject.name).to eq('John Smith')
         end
-        
+
         it 'exposes defined properties renamed from source' do
           expect(subject.years_of_age).to eq(34)
         end
-        
+
         it 'does not expose unspecified attributes' do
           expect(subject).to_not respond_to(:ssn)
           expect(subject).to_not respond_to(:age)
         end
       end
     end
-    
+
     context 'and a Shape decorator property with with: option and a from block' do
-      
+
       before do
         stub_const('ChildDecorator', Class.new do
           include Shape
@@ -460,76 +460,76 @@ describe Shape::PropertyShaper do
           end
         end)
       end
-      
+
       context 'when shaped by the decorator' do
-        
+
         subject {
           MockDecorator.new(source)
         }
-        
+
         it 'exposes and shapes each child element of the property with the provided decorator' do
           expect(subject.first_child.fullname).to eq('Jimmy Smith')
         end
-        
+
         specify do
           expect(subject.to_hash).to eq({ first_child: { fullname: 'Jimmy Smith' } })
         end
       end
     end
   end
-  
+
   context 'value resolution' do
     it 'resolves value from object method' do
       context_class.class_eval do
         property :name
       end
-      
+
       instance = context_class.new
       instance._source = source
       expect(instance.name).to eq('Alice')
     end
-    
+
     it 'resolves value from hash using symbol key' do
       context_class.class_eval do
         property :age
       end
-      
+
       instance = context_class.new
       instance._source = hash_source
       expect(instance.age).to eq(30)
     end
-    
+
     it 'resolves value from hash using string key fallback' do
       context_class.class_eval do
         property :name
       end
-      
+
       instance = context_class.new
       instance._source = hash_source
       expect(instance.name).to eq('Bob')
     end
-    
+
     it 'returns nil when key is not found' do
       context_class.class_eval do
         property :missing
       end
-      
+
       instance = context_class.new
       instance._source = hash_source
       expect(instance.missing).to be_nil
     end
-    
+
     it 'resolves using custom from alias' do
       context_class.class_eval do
         property :nickname, from: :name
       end
-      
+
       instance = context_class.new
       instance._source = source
       expect(instance.nickname).to eq('Alice')
     end
   end
-  
+
   context 'with and each_with' do
     before do
       stub_const('SimpleDecorator', Class.new do
@@ -540,22 +540,22 @@ describe Shape::PropertyShaper do
         include Shape::Base
       end)
     end
-    
+
     it 'shapes nested object with with: decorator' do
       ParentDecorator.class_eval do
         property :child, with: SimpleDecorator
       end
-      
+
       instance = ParentDecorator.new({ child: { name: 'Charlie' } })
       expect(instance.child).to be_a(SimpleDecorator)
       expect(instance.child.name).to eq('Charlie')
     end
-    
+
     it 'shapes collection with each_with: decorator' do
       ParentDecorator.class_eval do
         property :children, each_with: SimpleDecorator
       end
-      
+
       children = [
         { name: 'Zoe' },
         { name: 'Adam' }
@@ -563,12 +563,12 @@ describe Shape::PropertyShaper do
       instance = ParentDecorator.new({ children: children })
       expect(instance.children.map(&:name)).to contain_exactly('Zoe', 'Adam')
     end
-    
+
     it 'sorts shaped collection by provided attribute' do
       ParentDecorator.class_eval do
         property :children, each_with: SimpleDecorator, sort_by: :name
       end
-      
+
       unsorted = [
         { name: 'Zoe' },
         { name: 'Adam' }

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -543,7 +543,7 @@ describe Shape::PropertyShaper do
 
   context 'with and each_with' do
     let(:children) { [{ name: 'Zoe' }, { name: 'Adam' }] }
-    let(:unsorted) { [{ name: 'Zoe' }, { name: 'Adam' }] } # reverse to test sort, if needed
+    let(:unsorted) { [{ name: 'Zoe' }, { name: 'Adam' }] }
     let(:source) { { child: { name: 'Charlie' } } }
     let(:instance_one) { ParentDecorator.new(source) }
     let(:instance_two) { ParentDecorator.new(children: children) }

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -2,27 +2,44 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 require 'ostruct'
 
 describe Shape::PropertyShaper do
-
+  let(:context_class) do
+    Class.new do
+      include Shape::Base
+      attr_accessor :_source
+    end
+  end
+  
+  let(:source) do
+    OpenStruct.new(name: 'Alice', age: 42)
+  end
+  
+  let(:hash_source) do
+    {
+      'name' => 'Bob',
+      :age => 30
+    }
+  end
+  
   context 'Given an object with method attributes' do
-
+    
     let(:source) {
-      OpenStruct.new.tap do |person|
-      person.name  = 'John Smith'
-      person.age   = 34
-      person.ssn   = 123456789
-      person.children = [
-        OpenStruct.new.tap do |child|
-        child.name  = 'Jimmy Smith'
-        end,
-        OpenStruct.new.tap do |child|
-        child.name  = 'Jane Smith'
-        end,
-      ]
+      OpenStruct.new.tap do | person |
+        person.name = 'John Smith'
+        person.age = 34
+        person.ssn = 123456789
+        person.children = [
+          OpenStruct.new.tap do | child |
+            child.name = 'Jimmy Smith'
+          end,
+          OpenStruct.new.tap do | child |
+            child.name = 'Jane Smith'
+          end,
+        ]
       end
     }
-
+    
     context 'and a Shape decorator' do
-
+      
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -30,21 +47,21 @@ describe Shape::PropertyShaper do
           property :years_of_age, from: :age
         end)
       end
-
+      
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
-
+        
         it 'exposes defined properties from source' do
           expect(subject.name).to eq('John Smith')
         end
-
+        
         it 'exposes defined properties renamed from source' do
           expect(subject.years_of_age).to eq(34)
         end
-
+        
         it 'does not expose unspecified attributes' do
           expect(subject).to_not respond_to(:ssn)
           expect(subject).to_not respond_to(:age)
@@ -52,9 +69,9 @@ describe Shape::PropertyShaper do
       end
     end
   end
-
+  
   context 'Given a hash with attributes' do
-
+    
     let(:source) do
       {
         name: 'John Smith',
@@ -73,9 +90,9 @@ describe Shape::PropertyShaper do
         }
       }
     end
-
+    
     context 'and a Shape decorator' do
-
+      
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -83,30 +100,30 @@ describe Shape::PropertyShaper do
           property :years_of_age, from: :age
         end)
       end
-
+      
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
-
+        
         it 'exposes defined properties from source' do
           expect(subject.name).to eq('John Smith')
         end
-
+        
         it 'exposes defined properties renamed from source' do
           expect(subject.years_of_age).to eq(34)
         end
-
+        
         it 'does not expose unspecified attributes' do
           expect(subject).to_not respond_to(:ssn)
           expect(subject).to_not respond_to(:age)
         end
       end
     end
-
+    
     context 'and a Shape decorator property with each_with: option' do
-
+      
       before do
         stub_const('ChildDecorator', Class.new do
           include Shape::Base
@@ -117,68 +134,68 @@ describe Shape::PropertyShaper do
           property :children, each_with: ChildDecorator
         end)
       end
-
+      
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
-
+        
         it 'exposes and shapes each child element of the property with the provided decorator' do
-          expect(subject.children.map(&:name)).to eq(['Jimmy Smith', 'Jane Smith'])
+          expect(subject.children.map(&:name)).to eq([ 'Jimmy Smith', 'Jane Smith' ])
         end
       end
-
+      
       context 'and a sort_by: option' do
-
+        
         before do
           stub_const('MockDecorator', Class.new do
             include Shape::Base
             property :children, each_with: ChildDecorator, sort_by: :name
           end)
         end
-
+        
         context 'when shaped by the decorator' do
-
+          
           subject {
             MockDecorator.new(source)
           }
-
+          
           it 'sorts, exposes, and shapes each child element of the property with the provided decorator' do
-            expect(subject.children.map(&:name)).to eq(['Jane Smith', 'Jimmy Smith'])
+            expect(subject.children.map(&:name)).to eq([ 'Jane Smith', 'Jimmy Smith' ])
           end
         end
       end
     end
-
+    
     context 'and a Shape decorator property with with: option' do
-
+      
       before do
         stub_const('SpouseDecorator', Class.new do
           include Shape::Base
           property :name
         end)
-
+        
         stub_const('MockDecorator', Class.new do
           include Shape::Base
           property :spouse, with: SpouseDecorator
         end)
       end
-
+      
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
-
+        
         it 'exposes and shapes child element of the property with the provided decorator' do
           expect(subject.spouse.name).to eq('Sally Smith')
         end
       end
     end
-
+    
     context 'and a Shape decorator property with each_with: and from: options' do
-
+      
       before do
         stub_const('ChildDecorator', Class.new do
           include Shape::Base
@@ -189,58 +206,58 @@ describe Shape::PropertyShaper do
           property :dependents, from: :children, each_with: ChildDecorator
         end)
       end
-
+      
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
-
+        
         it 'exposes and shapes each child element of the property with the provided decorator' do
-          expect(subject.dependents.map(&:name)).to eq(['Jimmy Smith', 'Jane Smith'])
+          expect(subject.dependents.map(&:name)).to eq([ 'Jimmy Smith', 'Jane Smith' ])
         end
       end
     end
-
+    
     context 'and a Shape decorator property with each_with: and from: options and a decorator defined method' do
-
+      
       before do
         stub_const('ChildDecorator', Class.new do
           include Shape::Base
           property :name
         end)
-
+        
         stub_const('MockDecorator', Class.new do
           include Shape::Base
           property :dependents, from: :all_children, each_with: ChildDecorator
-
+          
           def all_children
             [
-              OpenStruct.new.tap do |child|
-              child.name  = 'Joseph Smith'
+              OpenStruct.new.tap do | child |
+                child.name = 'Joseph Smith'
               end,
-              OpenStruct.new.tap do |child|
-              child.name  = 'Janet Smith'
+              OpenStruct.new.tap do | child |
+                child.name = 'Janet Smith'
               end
             ]
           end
         end)
       end
-
+      
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
-
+        
         it 'exposes and shapes each child element of the property with the provided decorator' do
-          expect(subject.dependents.map(&:name)).to eq(['Joseph Smith', 'Janet Smith'])
+          expect(subject.dependents.map(&:name)).to eq([ 'Joseph Smith', 'Janet Smith' ])
         end
       end
     end
-
+    
     context 'and a Shape decorator property using a each_with block' do
-
+      
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -251,21 +268,21 @@ describe Shape::PropertyShaper do
           end
         end)
       end
-
+      
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
-
+        
         it 'exposes and shapes each child element of the property with the provided decorator' do
-          expect(subject.children.map(&:name)).to eq(['Jimmy Smith', 'Jane Smith'])
+          expect(subject.children.map(&:name)).to eq([ 'Jimmy Smith', 'Jane Smith' ])
         end
       end
     end
-
+    
     context 'and a Shape decorator property using a with block' do
-
+      
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -276,21 +293,21 @@ describe Shape::PropertyShaper do
           end
         end)
       end
-
+      
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
-
+        
         it 'exposes and shapes the child element of the property with the provided decorator' do
           expect(subject.spouse.name).to eq('Sally Smith')
         end
       end
     end
-
+    
     context 'and a Shape decorator property using from: option and a each_with block' do
-
+      
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -301,21 +318,21 @@ describe Shape::PropertyShaper do
           end
         end)
       end
-
+      
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
-
+        
         it 'exposes and shapes each child element of the property with the provided decorator' do
-          expect(subject.dependents.map(&:name)).to eq(['Jimmy Smith', 'Jane Smith'])
+          expect(subject.dependents.map(&:name)).to eq([ 'Jimmy Smith', 'Jane Smith' ])
         end
       end
     end
-
+    
     context 'and a Shape decorator property using from: option and a with block' do
-
+      
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -326,9 +343,9 @@ describe Shape::PropertyShaper do
           end
         end)
       end
-
+      
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
@@ -337,9 +354,9 @@ describe Shape::PropertyShaper do
         end
       end
     end
-
+    
     context 'given nested decorated properties' do
-
+      
       before do
         stub_const('MockDecorator', Class.new do
           include Shape
@@ -349,34 +366,34 @@ describe Shape::PropertyShaper do
           end
         end)
       end
-
+      
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
-
+        
         it 'exposes the nested properties' do
           expect(subject.to_hash[:dependents]).to eq({
-            spouse: {
-              name: 'Sally Smith'
-            },
-            children: [
-              {
-                name: 'Jimmy Smith'
-              },
-              {
-                name: 'Jane Smith'
-              }
-            ]
-          })
+                                                       spouse: {
+                                                         name: 'Sally Smith'
+                                                       },
+                                                       children: [
+                                                         {
+                                                           name: 'Jimmy Smith'
+                                                         },
+                                                         {
+                                                           name: 'Jane Smith'
+                                                         }
+                                                       ]
+                                                     })
         end
       end
     end
   end
-
+  
   context 'Given a hash with string attributes' do
-
+    
     let(:source) do
       {
         'name' => 'John Smith',
@@ -395,9 +412,9 @@ describe Shape::PropertyShaper do
         }
       }
     end
-
+    
     context 'and a Shape decorator' do
-
+      
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -405,30 +422,30 @@ describe Shape::PropertyShaper do
           property :years_of_age, from: :age
         end)
       end
-
+      
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
-
+        
         it 'exposes defined properties from source' do
           expect(subject.name).to eq('John Smith')
         end
-
+        
         it 'exposes defined properties renamed from source' do
           expect(subject.years_of_age).to eq(34)
         end
-
+        
         it 'does not expose unspecified attributes' do
           expect(subject).to_not respond_to(:ssn)
           expect(subject).to_not respond_to(:age)
         end
       end
     end
-
+    
     context 'and a Shape decorator property with with: option and a from block' do
-
+      
       before do
         stub_const('ChildDecorator', Class.new do
           include Shape
@@ -443,97 +460,77 @@ describe Shape::PropertyShaper do
           end
         end)
       end
-
+      
       context 'when shaped by the decorator' do
-
+        
         subject {
           MockDecorator.new(source)
         }
-
+        
         it 'exposes and shapes each child element of the property with the provided decorator' do
           expect(subject.first_child.fullname).to eq('Jimmy Smith')
         end
-
+        
         specify do
-          expect(subject.to_hash).to eq({first_child: {fullname: 'Jimmy Smith'}})
+          expect(subject.to_hash).to eq({ first_child: { fullname: 'Jimmy Smith' } })
         end
       end
     end
   end
-end
-
-RSpec.describe Shape::PropertyShaper do
-  let(:context_class) do
-    Class.new do
-      include Shape::Base
-      attr_accessor :_source
-    end
-  end
-
-  let(:source) do
-    OpenStruct.new(name: 'Alice', age: 42)
-  end
-
-  let(:hash_source) do
-    {
-      'name' => 'Bob',
-      :age => 30
-    }
-  end
-
-  describe 'value resolution' do
+  
+  context 'value resolution' do
     it 'resolves value from object method' do
       context_class.class_eval do
         property :name
       end
-
+      
       instance = context_class.new
       instance._source = source
       expect(instance.name).to eq('Alice')
     end
-
+    
     it 'resolves value from hash using symbol key' do
       context_class.class_eval do
         property :age
       end
-
+      
       instance = context_class.new
       instance._source = hash_source
       expect(instance.age).to eq(30)
     end
-
+    
     it 'resolves value from hash using string key fallback' do
       context_class.class_eval do
         property :name
       end
-
+      
       instance = context_class.new
       instance._source = hash_source
       expect(instance.name).to eq('Bob')
     end
-
+    
     it 'returns nil when key is not found' do
       context_class.class_eval do
         property :missing
       end
-
+      
       instance = context_class.new
       instance._source = hash_source
       expect(instance.missing).to be_nil
     end
-
+    
     it 'resolves using custom from alias' do
       context_class.class_eval do
         property :nickname, from: :name
       end
-
+      
       instance = context_class.new
       instance._source = source
       expect(instance.nickname).to eq('Alice')
     end
   end
-
-  describe 'with and each_with' do
+  
+  context 'with and each_with' do
     before do
       stub_const('SimpleDecorator', Class.new do
         include Shape::Base
@@ -543,22 +540,22 @@ RSpec.describe Shape::PropertyShaper do
         include Shape::Base
       end)
     end
-
+    
     it 'shapes nested object with with: decorator' do
       ParentDecorator.class_eval do
         property :child, with: SimpleDecorator
       end
-
+      
       instance = ParentDecorator.new({ child: { name: 'Charlie' } })
       expect(instance.child).to be_a(SimpleDecorator)
       expect(instance.child.name).to eq('Charlie')
     end
-
+    
     it 'shapes collection with each_with: decorator' do
       ParentDecorator.class_eval do
         property :children, each_with: SimpleDecorator
       end
-
+      
       children = [
         { name: 'Zoe' },
         { name: 'Adam' }
@@ -566,18 +563,18 @@ RSpec.describe Shape::PropertyShaper do
       instance = ParentDecorator.new({ children: children })
       expect(instance.children.map(&:name)).to contain_exactly('Zoe', 'Adam')
     end
-
+    
     it 'sorts shaped collection by provided attribute' do
       ParentDecorator.class_eval do
         property :children, each_with: SimpleDecorator, sort_by: :name
       end
-
+      
       unsorted = [
         { name: 'Zoe' },
         { name: 'Adam' }
       ]
       instance = ParentDecorator.new({ children: unsorted })
-      expect(instance.children.map(&:name)).to eq(['Adam', 'Zoe'])
+      expect(instance.children.map(&:name)).to eq([ 'Adam', 'Zoe' ])
     end
   end
 end

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -252,7 +252,7 @@ describe Shape::PropertyShaper do
       end
 
       context 'when shaped by the decorator' do
-       
+
         subject {
           MockDecorator.new(source)
         }
@@ -264,7 +264,7 @@ describe Shape::PropertyShaper do
     end
 
     context 'and a Shape decorator property using a with block' do
-     
+
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -277,7 +277,7 @@ describe Shape::PropertyShaper do
       end
 
       context 'when shaped by the decorator' do
-       
+
         subject {
           MockDecorator.new(source)
         }
@@ -289,7 +289,7 @@ describe Shape::PropertyShaper do
     end
 
     context 'and a Shape decorator property using from: option and a each_with block' do
-     
+
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -302,7 +302,7 @@ describe Shape::PropertyShaper do
       end
 
       context 'when shaped by the decorator' do
-       
+
         subject {
           MockDecorator.new(source)
         }
@@ -314,7 +314,7 @@ describe Shape::PropertyShaper do
     end
 
     context 'and a Shape decorator property using from: option and a with block' do
-     
+
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -327,7 +327,7 @@ describe Shape::PropertyShaper do
       end
 
       context 'when shaped by the decorator' do
-       
+
         subject {
           MockDecorator.new(source)
         }
@@ -396,7 +396,7 @@ describe Shape::PropertyShaper do
     end
 
     context 'and a Shape decorator' do
-     
+
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -444,7 +444,7 @@ describe Shape::PropertyShaper do
       end
 
       context 'when shaped by the decorator' do
-        
+
         subject {
           MockDecorator.new(source)
         }
@@ -470,75 +470,75 @@ RSpec.describe Shape::PropertyShaper do
       attr_accessor :_source
     end
   end
- 
+
   let(:source) do
     OpenStruct.new(name: 'Alice', age: 42)
   end
- 
+
   let(:hash_source) do
     {
       'name' => 'Bob',
       :age => 30
     }
   end
- 
+
   describe 'value resolution' do
     it 'resolves value from object method' do
-     
+
       context_class.class_eval do
         property :name
       end
-     
+
       instance = context_class.new
       instance._source = source
       expect(instance.name).to eq('Alice')
     end
-   
+
     it 'resolves value from hash using symbol key' do
-     
+
       context_class.class_eval do
         property :age
       end
-     
+
       instance = context_class.new
       instance._source = hash_source
       expect(instance.age).to eq(30)
     end
-   
+
     it 'resolves value from hash using string key fallback' do
-     
+
       context_class.class_eval do
         property :name
       end
-     
+
       instance = context_class.new
       instance._source = hash_source
       expect(instance.name).to eq('Bob')
     end
-   
+
     it 'returns nil when key is not found' do
-      
+
       context_class.class_eval do
         property :missing
       end
-     
+
       instance = context_class.new
       instance._source = hash_source
       expect(instance.missing).to be_nil
     end
-   
+
     it 'resolves using custom from alias' do
-    
+
       context_class.class_eval do
         property :nickname, from: :name
       end
-    
+
       instance = context_class.new
       instance._source = source
       expect(instance.nickname).to eq('Alice')
     end
   end
- 
+
   describe 'with and each_with' do
     before do
       stub_const('SimpleDecorator', Class.new do
@@ -549,24 +549,24 @@ RSpec.describe Shape::PropertyShaper do
         include Shape::Base
       end)
     end
-   
+
     it 'shapes nested object with with: decorator' do
-      
+
       ParentDecorator.class_eval do
         property :child, with: SimpleDecorator
       end
-      
+
       instance = ParentDecorator.new({ child: { name: 'Charlie' } })
       expect(instance.child).to be_a(SimpleDecorator)
       expect(instance.child.name).to eq('Charlie')
     end
-    
+
     it 'shapes collection with each_with: decorator' do
-      
+
       ParentDecorator.class_eval do
         property :children, each_with: SimpleDecorator
       end
-      
+
       children = [
         { name: 'Zoe' },
         { name: 'Adam' }
@@ -574,13 +574,13 @@ RSpec.describe Shape::PropertyShaper do
       instance = ParentDecorator.new({ children: children })
       expect(instance.children.map(&:name)).to contain_exactly('Zoe', 'Adam')
     end
-   
+
     it 'sorts shaped collection by provided attribute' do
-      
+
       ParentDecorator.class_eval do
         property :children, each_with: SimpleDecorator, sort_by: :name
       end
-      
+
       unsorted = [
         { name: 'Zoe' },
         { name: 'Adam' }

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -507,3 +507,132 @@ describe Shape::PropertyShaper do
   end
 
 end
+
+require 'ostruct'
+
+RSpec.describe Shape::PropertyShaper do
+  let(:context_class) do
+    Class.new do
+      include Shape::Base
+      attr_accessor :_source
+    end
+  end
+  
+  let(:source) do
+    OpenStruct.new(name: 'Alice', age: 42)
+  end
+  
+  let(:hash_source) do
+    {
+      'name' => 'Bob',
+      :age => 30
+    }
+  end
+  
+  describe 'value resolution' do
+    it 'resolves value from object method' do
+      context_class.class_eval do
+        property :name
+      end
+      instance = context_class.new
+      instance._source = source
+      
+      expect(instance.name).to eq('Alice')
+    end
+    
+    it 'resolves value from hash using symbol key' do
+      context_class.class_eval do
+        property :age
+      end
+      instance = context_class.new
+      instance._source = hash_source
+      
+      expect(instance.age).to eq(30)
+    end
+    
+    it 'resolves value from hash using string key fallback' do
+      context_class.class_eval do
+        property :name
+      end
+      instance = context_class.new
+      instance._source = hash_source
+      
+      expect(instance.name).to eq('Bob')
+    end
+    
+    it 'returns nil when key is not found' do
+      context_class.class_eval do
+        property :missing
+      end
+      instance = context_class.new
+      instance._source = hash_source
+      
+      expect(instance.missing).to be_nil
+    end
+    
+    it 'resolves using custom from alias' do
+      context_class.class_eval do
+        property :nickname, from: :name
+      end
+      instance = context_class.new
+      instance._source = source
+      
+      expect(instance.nickname).to eq('Alice')
+    end
+  end
+  
+  describe 'with and each_with' do
+    before do
+      stub_const('SimpleDecorator', Class.new do
+        include Shape::Base
+        property :name
+      end)
+      
+      stub_const('ParentDecorator', Class.new do
+        include Shape::Base
+      end)
+    end
+    
+    it 'shapes nested object with with: decorator' do
+      ParentDecorator.class_eval do
+        property :child, with: SimpleDecorator
+      end
+      
+      instance = ParentDecorator.new({ child: { name: 'Charlie' } })
+      
+      expect(instance.child).to be_a(SimpleDecorator)
+      expect(instance.child.name).to eq('Charlie')
+    end
+    
+    it 'shapes collection with each_with: decorator' do
+      ParentDecorator.class_eval do
+        property :children, each_with: SimpleDecorator
+      end
+      
+      children = [
+        { name: 'Zoe' },
+        { name: 'Adam' }
+      ]
+      
+      instance = ParentDecorator.new({ children: children })
+      
+      expect(instance.children.map(&:name)).to contain_exactly('Zoe', 'Adam')
+    end
+    
+    it 'sorts shaped collection by provided attribute' do
+      ParentDecorator.class_eval do
+        property :children, each_with: SimpleDecorator, sort_by: :name
+      end
+      
+      unsorted = [
+        { name: 'Zoe' },
+        { name: 'Adam' }
+      ]
+      
+      instance = ParentDecorator.new({ children: unsorted })
+      
+      expect(instance.children.map(&:name)).to eq(['Adam', 'Zoe'])
+    end
+  end
+end
+

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -28,7 +28,6 @@ describe Shape::PropertyShaper do
           property :name
           property :years_of_age, from: :age
         end)
-
       end
 
       context 'when shaped by the decorator' do
@@ -188,7 +187,6 @@ describe Shape::PropertyShaper do
           include Shape::Base
           property :dependents, from: :children, each_with: ChildDecorator
         end)
-
       end
 
       context 'when shaped by the decorator' do
@@ -200,9 +198,7 @@ describe Shape::PropertyShaper do
         it 'exposes and shapes each child element of the property with the provided decorator' do
           expect(subject.dependents.map(&:name)).to eq(['Jimmy Smith', 'Jane Smith'])
         end
-
       end
-
     end
 
     context 'and a Shape decorator property with each_with: and from: options and a decorator defined method' do
@@ -256,7 +252,7 @@ describe Shape::PropertyShaper do
       end
 
       context 'when shaped by the decorator' do
-        
+       
         subject {
           MockDecorator.new(source)
         }
@@ -268,7 +264,7 @@ describe Shape::PropertyShaper do
     end
 
     context 'and a Shape decorator property using a with block' do
-      
+     
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -281,7 +277,7 @@ describe Shape::PropertyShaper do
       end
 
       context 'when shaped by the decorator' do
-        
+       
         subject {
           MockDecorator.new(source)
         }
@@ -293,7 +289,7 @@ describe Shape::PropertyShaper do
     end
 
     context 'and a Shape decorator property using from: option and a each_with block' do
-      
+     
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -306,7 +302,7 @@ describe Shape::PropertyShaper do
       end
 
       context 'when shaped by the decorator' do
-        
+       
         subject {
           MockDecorator.new(source)
         }
@@ -318,7 +314,7 @@ describe Shape::PropertyShaper do
     end
 
     context 'and a Shape decorator property using from: option and a with block' do
-      
+     
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -331,7 +327,7 @@ describe Shape::PropertyShaper do
       end
 
       context 'when shaped by the decorator' do
-        
+       
         subject {
           MockDecorator.new(source)
         }
@@ -340,7 +336,6 @@ describe Shape::PropertyShaper do
         end
       end
     end
-
 
     context 'given nested decorated properties' do
 
@@ -401,7 +396,7 @@ describe Shape::PropertyShaper do
     end
 
     context 'and a Shape decorator' do
-      
+     
       before do
         stub_const('MockDecorator', Class.new do
           include Shape::Base
@@ -464,7 +459,6 @@ describe Shape::PropertyShaper do
       end
     end
   end
-
 end
 
 require 'ostruct'
@@ -476,76 +470,75 @@ RSpec.describe Shape::PropertyShaper do
       attr_accessor :_source
     end
   end
-  
+ 
   let(:source) do
     OpenStruct.new(name: 'Alice', age: 42)
   end
-  
+ 
   let(:hash_source) do
     {
       'name' => 'Bob',
       :age => 30
     }
   end
-  
+ 
   describe 'value resolution' do
     it 'resolves value from object method' do
-      
+     
       context_class.class_eval do
         property :name
       end
-      
+     
       instance = context_class.new
       instance._source = source
       expect(instance.name).to eq('Alice')
     end
-    
+   
     it 'resolves value from hash using symbol key' do
-      
+     
       context_class.class_eval do
         property :age
       end
-      
+     
       instance = context_class.new
       instance._source = hash_source
       expect(instance.age).to eq(30)
     end
-    
+   
     it 'resolves value from hash using string key fallback' do
-      
+     
       context_class.class_eval do
         property :name
       end
-      
+     
       instance = context_class.new
       instance._source = hash_source
       expect(instance.name).to eq('Bob')
     end
-    
+   
     it 'returns nil when key is not found' do
       
       context_class.class_eval do
         property :missing
       end
-      
+     
       instance = context_class.new
       instance._source = hash_source
       expect(instance.missing).to be_nil
     end
-    
+   
     it 'resolves using custom from alias' do
-      
+    
       context_class.class_eval do
         property :nickname, from: :name
       end
-      
-      
+    
       instance = context_class.new
       instance._source = source
       expect(instance.nickname).to eq('Alice')
     end
   end
-  
+ 
   describe 'with and each_with' do
     before do
       stub_const('SimpleDecorator', Class.new do
@@ -556,7 +549,7 @@ RSpec.describe Shape::PropertyShaper do
         include Shape::Base
       end)
     end
-    
+   
     it 'shapes nested object with with: decorator' do
       
       ParentDecorator.class_eval do
@@ -581,7 +574,7 @@ RSpec.describe Shape::PropertyShaper do
       instance = ParentDecorator.new({ children: children })
       expect(instance.children.map(&:name)).to contain_exactly('Zoe', 'Adam')
     end
-    
+   
     it 'sorts shaped collection by provided attribute' do
       
       ParentDecorator.class_eval do

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -276,7 +276,7 @@ describe Shape::PropertyShaper do
         }
 
         it 'exposes and shapes each child element of the property with the provided decorator' do
-          expect(subject.children.map(&:name)).to eq([ 'Jimmy Smith', 'Jane Smith' ])
+          expect(subject.children.map(&:name)).to eq(['Jimmy Smith', 'Jane Smith'])
         end
       end
     end
@@ -375,18 +375,18 @@ describe Shape::PropertyShaper do
 
         it 'exposes the nested properties' do
           expect(subject.to_hash[:dependents]).to eq({
-                                                       spouse: {
-                                                         name: 'Sally Smith'
-                                                       },
-                                                       children: [
-                                                         {
-                                                           name: 'Jimmy Smith'
-                                                         },
-                                                         {
-                                                           name: 'Jane Smith'
-                                                         }
-                                                       ]
-                                                     })
+            spouse: {
+               name: 'Sally Smith'
+            },
+            children: [
+              {
+                name: 'Jimmy Smith'
+              },
+              {
+                name: 'Jane Smith'
+               }
+            ]
+          })
         end
       end
     end

--- a/spec/property_shaper_spec.rb
+++ b/spec/property_shaper_spec.rb
@@ -534,11 +534,9 @@ describe Shape::PropertyShaper do
 
   context 'with and each_with' do
     let(:children) { [{ name: 'Zoe' }, { name: 'Adam' }] }
-    let(:unsorted) { [{ name: 'Zoe' }, { name: 'Adam' }] }
     let(:source) { { child: { name: 'Charlie' } } }
     let(:instance_one) { ParentDecorator.new(source) }
     let(:instance_two) { ParentDecorator.new(children: children) }
-    let(:instance_three) { ParentDecorator.new(children: unsorted) }
 
     before do
       stub_const('SimpleDecorator', Class.new do
@@ -573,7 +571,7 @@ describe Shape::PropertyShaper do
         property :children, each_with: SimpleDecorator, sort_by: :name
       end
 
-      expect(instance_three.children.map(&:name)).to eq(['Adam', 'Zoe'])
+      expect(instance_two.children.map(&:name)).to eq(['Adam', 'Zoe'])
     end
   end
 end


### PR DESCRIPTION
This PR updates the Shape gem serialization logic to correctly handle boolean false values. Previously, false inputs were serialized as nil or omitted, causing incorrect data representation.

With this change, false values are explicitly serialized as false, ensuring accurate and expected output.

Key points:

Fixed serialization to distinguish false from nil.

Prevents loss or misinterpretation of boolean flags during serialization.

Aligns serialization behavior with the accepted criteria that false should remain false in the output.
<img width="789" height="422" alt="image-20250714-125429" src="https://github.com/user-attachments/assets/86f92d6b-0003-4ff5-a74f-05405c1bc473" />

